### PR TITLE
Feat: user list item box 공통 컴포넌트 구현

### DIFF
--- a/src/Menu/page.tsx
+++ b/src/Menu/page.tsx
@@ -1,4 +1,4 @@
-import UserListItemBox from "@/common/components/UserListItemBox";
+import UserListItemCard from "@/common/components/UserListItemCard";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
 import { Blockquote, Card, Checkbox, Flex, Heading, Radio, Text } from "@radix-ui/themes";
@@ -18,19 +18,19 @@ export default function MenuPage() {
 
       <UserListContainer>
         <Flex direction="column" gap="2">
-          <UserListItemBox asChild>
+          <UserListItemCard asChild>
             <Link to="/">
               <Flex>유저1</Flex>
             </Link>
-          </UserListItemBox>
+          </UserListItemCard>
 
-          <UserListItemBox asChild>
+          <UserListItemCard asChild>
             <button type="button" onClick={() => console.log("here")}>
               유저2
             </button>
-          </UserListItemBox>
+          </UserListItemCard>
 
-          <UserListItemBox>
+          <UserListItemCard>
             <Flex gap="3">
               <Text as="label" size="2">
                 <Radio name="example" value="1" defaultChecked color="indigo" />
@@ -42,9 +42,9 @@ export default function MenuPage() {
                 Comfortable
               </Text>
             </Flex>
-          </UserListItemBox>
+          </UserListItemCard>
 
-          <UserListItemBox>유저4</UserListItemBox>
+          <UserListItemCard>유저4</UserListItemCard>
         </Flex>
       </UserListContainer>
     </>

--- a/src/Menu/page.tsx
+++ b/src/Menu/page.tsx
@@ -1,6 +1,9 @@
+import UserListItemBox from "@/common/components/UserListItemBox";
 import { css } from "@emotion/react";
-import { Blockquote, Card, Checkbox, Heading } from "@radix-ui/themes";
+import styled from "@emotion/styled";
+import { Blockquote, Card, Checkbox, Flex, Heading, Radio, Text } from "@radix-ui/themes";
 import { version } from "react";
+import { Link } from "react-router";
 
 export default function MenuPage() {
   return (
@@ -12,6 +15,43 @@ export default function MenuPage() {
         heading
       </Heading>
       <Blockquote weight="bold">quote quote</Blockquote>
+
+      <UserListContainer>
+        <Flex direction="column" gap="2">
+          <UserListItemBox asChild>
+            <Link to="/">
+              <Flex>유저1</Flex>
+            </Link>
+          </UserListItemBox>
+
+          <UserListItemBox asChild>
+            <button type="button" onClick={() => console.log("here")}>
+              유저2
+            </button>
+          </UserListItemBox>
+
+          <UserListItemBox>
+            <Flex gap="3">
+              <Text as="label" size="2">
+                <Radio name="example" value="1" defaultChecked color="indigo" />
+                Default
+              </Text>
+
+              <Text as="label" size="2">
+                <Radio name="example" value="1" color="cyan" />
+                Comfortable
+              </Text>
+            </Flex>
+          </UserListItemBox>
+
+          <UserListItemBox>유저4</UserListItemBox>
+        </Flex>
+      </UserListContainer>
     </>
   );
 }
+
+const UserListContainer = styled.div({
+  width: "100vw",
+  padding: "10px",
+});

--- a/src/common/components/UserListItemBox.tsx
+++ b/src/common/components/UserListItemBox.tsx
@@ -1,11 +1,9 @@
 import { Card, type CardProps } from "@radix-ui/themes";
 import type { ReactNode } from "react";
 
-interface UserBoxProps {
+interface Props extends CardProps {
   children: ReactNode;
 }
-
-type Props = UserBoxProps & CardProps;
 
 export default function UserListItemBox({ children, ...props }: Props) {
   return (

--- a/src/common/components/UserListItemBox.tsx
+++ b/src/common/components/UserListItemBox.tsx
@@ -1,0 +1,16 @@
+import { Card, type CardProps } from "@radix-ui/themes";
+import type { ReactNode } from "react";
+
+interface UserBoxProps {
+  children: ReactNode;
+}
+
+type Props = UserBoxProps & CardProps;
+
+export default function UserListItemBox({ children, ...props }: Props) {
+  return (
+    <Card variant="classic" {...props}>
+      {children}
+    </Card>
+  );
+}

--- a/src/common/components/UserListItemCard.tsx
+++ b/src/common/components/UserListItemCard.tsx
@@ -5,7 +5,7 @@ interface Props extends CardProps {
   children: ReactNode;
 }
 
-export default function UserListItemBox({ children, ...props }: Props) {
+export default function UserListItemCard({ children, ...props }: Props) {
   return (
     <Card variant="classic" {...props}>
       {children}


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #8

## ☑️ 완료 태스크
- [x] user list item box 공통 컴포넌트 구현

<br />

## 🔎 PR 내용

<!-- 팀원들에게 PR의 내용을 설명해주세요 -->
<!-- 기록하고 싶은 트러블 슈팅이나 어려웠던 혹은 공유하고 싶었던 챌린징 요소들도 함께 적어줘도 괜찮아요 -->

논의했던 대로 어떻게 공통된 ui만을 위한 컴포넌트를 만들지 고민하다가, 직접적인 스타일링도 시도해보았는데
Radix ui를 적극 활용하기로 한 만큼, Radix를 활용하는 것이 좋겠다고 생각했어요

그 중 [Card](https://www.radix-ui.com/themes/playground#card) 컴포넌트가 유저 리스트 아이템 박스로 활용하기 가장 적합하고, 또 충분한 컴포넌트라고 판단했습니다
> Card: Container that groups related content and actions.

Card의 variant는 classic으로 설정했고, 확장성을 위해 Card Props를 그대로 열어두었어요.

네이밍도 고민을 많이 했는데,
**유저 리스트**에 쓰이는 **아이템의 외부 박스**라는 의미에서 `<UserListItemBox>` 라고 명명했습니다

고민을 거듭할수록 Radix 예시 코드를 많이 보면서 어떻게 선언적으로 코드를 구성하는지 많이 익혀두면 좋겠다는 생각이 들어요!
`asChild` prop을 이용해 UserListItemBox를 원하는 태그로 사용할 수도 있는데, 그 예시도 적용해두었습니다

@jungwoo3490 와는 이미 논의가 한 번 이루어져서, @Yeonseo-Jo 의 리뷰는 꼭 받고 머지할게요! ☀️

<br />

## 📷 스크린샷
![image](https://github.com/user-attachments/assets/dda9d7d6-b264-401d-ac72-920aae633ab4)

<!-- 팀원들이 이해할 수 있게 구현한 화면을 보여주세요 -->
