### PR TITLE
Feat: user profile Avatar 공통 컴포넌트 구현

### DIFF
--- a/src/Menu/page.tsx
+++ b/src/Menu/page.tsx
@@ -1,7 +1,16 @@
 import UserListItemCard from "@/common/components/UserListItemCard";
+import UserProfileAvatar from "@/common/components/UserProfileAvatar";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { Blockquote, Card, Checkbox, Flex, Heading, Radio, Text } from "@radix-ui/themes";
+import {
+  Blockquote,
+  Card,
+  Checkbox,
+  Flex,
+  Heading,
+  Radio,
+  Text,
+} from "@radix-ui/themes";
 import { version } from "react";
 import { Link } from "react-router";
 
@@ -10,6 +19,7 @@ export default function MenuPage() {
     <>
       {version}
       <Card variant="surface">menu</Card>
+
       <Checkbox defaultChecked />
       <Heading size="6" css={css({ color: "red" })}>
         heading
@@ -50,6 +60,10 @@ export default function MenuPage() {
           <UserListItemCard>유저4</UserListItemCard>
         </Flex>
       </UserListContainer>
+
+      {/* fallback이 보여지는 케이스 -> 이미지 로딩 실패시 */}
+      <UserProfileAvatar size="9" />
+      <UserProfileAvatar src="https://picsum.photos/id/237/200/300" size="9" />
     </>
   );
 }

--- a/src/common/components/UserProfileAvatar.tsx
+++ b/src/common/components/UserProfileAvatar.tsx
@@ -1,0 +1,20 @@
+import { Avatar, type AvatarProps } from "@radix-ui/themes";
+
+type UserProfileAvatarProps = Omit<
+  AvatarProps,
+  "radius" | "variant" | "color" | "fallback"
+>;
+
+const UserProfileAvatar = ({ ...props }: UserProfileAvatarProps) => {
+  return (
+    <Avatar
+      radius="full"
+      variant="soft"
+      color="gray"
+      fallback={<>fallback image</>}
+      {...props}
+    />
+  );
+};
+
+export default UserProfileAvatar;

--- a/src/common/components/UserProfileAvatar.tsx
+++ b/src/common/components/UserProfileAvatar.tsx
@@ -5,7 +5,7 @@ type UserProfileAvatarProps = Omit<
   "radius" | "variant" | "color" | "fallback"
 >;
 
-const UserProfileAvatar = ({ ...props }: UserProfileAvatarProps) => {
+const UserProfileAvatar = (props: UserProfileAvatarProps) => {
   return (
     <Avatar
       radius="full"


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #13 

## ☑️ 완료 태스크
- [x] radix의 [Avatar 컴포넌트](https://www.radix-ui.com/themes/docs/components/avatar#radius) 활용해서 UserProfile 공통 컴포넌트 구현

<br />

## 🔎 PR 내용

<!-- 팀원들에게 PR의 내용을 설명해주세요 -->
<!-- 기록하고 싶은 트러블 슈팅이나 어려웠던 혹은 공유하고 싶었던 챌린징 요소들도 함께 적어줘도 괜찮아요 -->

#### UserProfileAvatar component
  * userProfile을 구현할 때 사용할, Avatar UI component를 추상화 한 공통 컴포넌트라는 의미로 `<UserProfileAvatar>`라고 네이밍 했습니다!
  * `prop` : radix의 Avatar 컴포넌트 props 중, 공통으로 고정해두고 사용할 속성(radius, varaint, color, fallback) 제외한 prop들 
  * [[ > Avatr prop 세부 정보 ]](https://www.radix-ui.com/themes/docs/components/avatar#api-reference) 

#### (radix) Avatar 컴포넌트의 세부 동작
*  Avatar 컴포넌트 : span 태그로 감싸진 img태그 
    ➡ img 관련 attribute들 (ex. alt 등) 적용 가능
* loading 시에는 img 태그를 감싸는 span 태그만 보여짐 
   ➡ 이 span 태그의 background === color prop에 의존하므로, 로딩 시 color prop으로 지정해준 색상의 태그가 보여지게 됨 (스켈레톤처럼 동작!)
* img 로드 실패 시, fallback prop으로 넘겨준 element가 보여짐
* [ [ > 코드가 궁금하다면 여기를 참고하세용 ] ](https://github.com/radix-ui/themes/blob/main/packages/radix-ui-themes/src/components/avatar.tsx)

#### 🙋🏻‍♀️ 논의가 필요한 점
1. `color prop으로 gray가 적절할지?`
: Avatar 컴포넌트 설계 구조상, 스켈레톤 동작처럼 이미지 source가 로드되기 전까지 color에 넘겨준 color 값으로 보여지게 되어요. 
이때 넘길 수 있는 값이 enum으로 제한되어 있어, gray scale 색상으로 사용하기로 한 Slate 색상을 사용할수 없어 gray로 지정했는데 어떤것 같나욤?
다른 main color를 사용하는것보다 gray 계열을 사용하는 것이 자연스러운것 같아 우선 gray로 지정해놨어요

2. `fallback img로 어떤걸 보여줄지`
: 요건 구두로 짧게 논의해보면 좋을것 같아 회의 안건으로 올려두겠습니둥~




<br />

## 📷 스크린샷

<!-- 팀원들이 이해할 수 있게 구현한 화면을 보여주세요 -->

menu 페이지에 테스트 코드를 추가해두었습니당 (fallback인 경우 / 이미지를 성공적으로 받아왔을 경우)

https://github.com/user-attachments/assets/39c2e507-b93c-49bb-8f54-5dcaa6390616

