### PR TITLE
Feat: 공통 Header를 구현합니다.

### DIFF
--- a/src/Menu/page.tsx
+++ b/src/Menu/page.tsx
@@ -1,13 +1,27 @@
+import Header from "@/common/components/Header";
 import UserListItemCard from "@/common/components/UserListItemCard";
 import { css } from "@emotion/react";
 import styled from "@emotion/styled";
-import { Blockquote, Card, Checkbox, Flex, Heading, Radio, Text } from "@radix-ui/themes";
+import {
+  Blockquote,
+  Card,
+  Checkbox,
+  Flex,
+  Heading,
+  Radio,
+  Text,
+} from "@radix-ui/themes";
 import { version } from "react";
 import { Link } from "react-router";
 
 export default function MenuPage() {
   return (
-    <>
+    <div>
+      <Header
+        leftElement={"왼쪽"}
+        centerElement={"중앙"}
+        rightElement={"오른쪽"}
+      />
       {version}
       <Card variant="surface">menu</Card>
       <Checkbox defaultChecked />
@@ -50,11 +64,11 @@ export default function MenuPage() {
           <UserListItemCard>유저4</UserListItemCard>
         </Flex>
       </UserListContainer>
-    </>
+    </div>
   );
 }
 
 const UserListContainer = styled.div({
   width: "100vw",
-  padding: "10px",
+  padding: "1rem",
 });

--- a/src/common/components/Header.tsx
+++ b/src/common/components/Header.tsx
@@ -1,0 +1,48 @@
+import { Flex } from "@radix-ui/themes";
+import type { ReactNode } from "react";
+import styled from "@emotion/styled";
+
+interface HeaderProps {
+  leftElement?: ReactNode;
+  centerElement: ReactNode;
+  rightElement?: ReactNode;
+}
+
+function Header({ leftElement, centerElement, rightElement }: HeaderProps) {
+  return (
+    <HeaderWrapper aria-label="페이지 헤더">
+      <Flex height="100%" align="center">
+        <LeftElement>{leftElement}</LeftElement>
+        <CenterElement>{centerElement}</CenterElement>
+        <RightElement>{rightElement}</RightElement>
+      </Flex>
+    </HeaderWrapper>
+  );
+}
+
+export default Header;
+
+const HeaderWrapper = styled.header({
+  position: "sticky",
+  zIndex: 999,
+  top: 0,
+
+  width: "100%",
+  height: "4.8rem",
+
+  backgroundColor: "white",
+});
+
+const LeftElement = styled.div`
+  position: absolute;
+  left: 1.5rem;
+`;
+
+const CenterElement = styled.div`
+  margin: 0 auto;
+`;
+
+const RightElement = styled.div`
+  position: absolute;
+  right: 1.5rem;
+`;

--- a/src/common/components/Header.tsx
+++ b/src/common/components/Header.tsx
@@ -35,16 +35,16 @@ const HeaderWrapper = styled.header({
   backgroundColor: "white",
 });
 
-const LeftElement = styled.div`
-  position: absolute;
-  left: 1.5rem;
-`;
+const LeftElement = styled.div({
+  position: "absolute",
+  left: "1.5rem",
+});
 
-const CenterElement = styled.div`
-  margin: 0 auto;
-`;
+const CenterElement = styled.div({
+  margin: "0 auto",
+});
 
-const RightElement = styled.div`
-  position: absolute;
-  right: 1.5rem;
-`;
+const RightElement = styled.div({
+  position: "absolute",
+  right: "1.5rem",
+});

--- a/src/common/components/Header.tsx
+++ b/src/common/components/Header.tsx
@@ -1,5 +1,6 @@
 import type { ReactElement } from "react";
 import styled from "@emotion/styled";
+import { Z_INDEX } from "../constants/zIndex";
 
 interface HeaderProps {
   leftElement?: ReactElement | string;
@@ -23,7 +24,7 @@ export default Header;
 
 const HeaderWrapper = styled.header({
   position: "sticky",
-  zIndex: 999,
+  zIndex: Z_INDEX.HEADER,
   top: 0,
 
   display: "flex",

--- a/src/common/components/Header.tsx
+++ b/src/common/components/Header.tsx
@@ -28,7 +28,6 @@ const HeaderWrapper = styled.header({
   top: 0,
 
   display: "flex",
-  alignItems: "center",
 
   width: "100%",
   height: "4.8rem",
@@ -37,15 +36,29 @@ const HeaderWrapper = styled.header({
 });
 
 const LeftElement = styled.div({
+  display: "flex",
+  alignItems: "center",
+
   position: "absolute",
   left: "1.5rem",
+
+  height: "100%",
 });
 
 const CenterElement = styled.div({
+  display: "flex",
+  alignItems: "center",
+
   margin: "0 auto",
+  height: "100%",
 });
 
 const RightElement = styled.div({
+  display: "flex",
+  alignItems: "center",
+
   position: "absolute",
   right: "1.5rem",
+
+  height: "100%",
 });

--- a/src/common/components/Header.tsx
+++ b/src/common/components/Header.tsx
@@ -11,7 +11,9 @@ function Header({ leftElement, centerElement, rightElement }: HeaderProps) {
   return (
     <HeaderWrapper aria-label="페이지 헤더">
       <LeftElement>{leftElement}</LeftElement>
-      <CenterElement>{centerElement}</CenterElement>
+      <CenterElement as={typeof centerElement === "string" ? "h1" : "div"}>
+        {centerElement}
+      </CenterElement>
       <RightElement>{rightElement}</RightElement>
     </HeaderWrapper>
   );

--- a/src/common/components/Header.tsx
+++ b/src/common/components/Header.tsx
@@ -1,10 +1,10 @@
-import type { ReactNode } from "react";
+import type { ReactElement } from "react";
 import styled from "@emotion/styled";
 
 interface HeaderProps {
-  leftElement?: ReactNode;
-  centerElement: ReactNode;
-  rightElement?: ReactNode;
+  leftElement?: ReactElement | string;
+  centerElement: ReactElement | string;
+  rightElement?: ReactElement | string;
 }
 
 function Header({ leftElement, centerElement, rightElement }: HeaderProps) {

--- a/src/common/components/Header.tsx
+++ b/src/common/components/Header.tsx
@@ -3,19 +3,19 @@ import styled from "@emotion/styled";
 import { Z_INDEX } from "../constants/zIndex";
 
 interface HeaderProps {
-  leftElement?: ReactElement | string;
-  centerElement: ReactElement | string;
-  rightElement?: ReactElement | string;
+  left?: ReactElement | string;
+  center: ReactElement | string;
+  right?: ReactElement | string;
 }
 
-function Header({ leftElement, centerElement, rightElement }: HeaderProps) {
+function Header({ left, center, right }: HeaderProps) {
   return (
     <HeaderWrapper aria-label="페이지 헤더">
-      <LeftElement>{leftElement}</LeftElement>
-      <CenterElement as={typeof centerElement === "string" ? "h1" : "div"}>
-        {centerElement}
+      <LeftElement>{left}</LeftElement>
+      <CenterElement as={typeof center === "string" ? "h1" : "div"}>
+        {center}
       </CenterElement>
-      <RightElement>{rightElement}</RightElement>
+      <RightElement>{right}</RightElement>
     </HeaderWrapper>
   );
 }

--- a/src/common/components/Header.tsx
+++ b/src/common/components/Header.tsx
@@ -1,4 +1,3 @@
-import { Flex } from "@radix-ui/themes";
 import type { ReactNode } from "react";
 import styled from "@emotion/styled";
 
@@ -11,11 +10,9 @@ interface HeaderProps {
 function Header({ leftElement, centerElement, rightElement }: HeaderProps) {
   return (
     <HeaderWrapper aria-label="페이지 헤더">
-      <Flex height="100%" align="center">
-        <LeftElement>{leftElement}</LeftElement>
-        <CenterElement>{centerElement}</CenterElement>
-        <RightElement>{rightElement}</RightElement>
-      </Flex>
+      <LeftElement>{leftElement}</LeftElement>
+      <CenterElement>{centerElement}</CenterElement>
+      <RightElement>{rightElement}</RightElement>
     </HeaderWrapper>
   );
 }
@@ -26,6 +23,9 @@ const HeaderWrapper = styled.header({
   position: "sticky",
   zIndex: 999,
   top: 0,
+
+  display: "flex",
+  alignItems: "center",
 
   width: "100%",
   height: "4.8rem",

--- a/src/common/constants/zIndex.ts
+++ b/src/common/constants/zIndex.ts
@@ -1,0 +1,5 @@
+export const Z_INDEX = {
+  MODAL: 1000,
+  DROPDOWN: 100,
+  HEADER: 10,
+} as const;


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #7 

## ☑️ 완료 태스크
- [x] 공통 Header 구현

<br />

## 🔎 PR 내용

<!-- 팀원들에게 PR의 내용을 설명해주세요 -->
<!-- 기록하고 싶은 트러블 슈팅이나 어려웠던 혹은 공유하고 싶었던 챌린징 요소들도 함께 적어줘도 괜찮아요 -->

### Interface 설계
와이어프레임을 확인해보면 Header의 중앙 Element는 항상 존재하기 때문에 required prop으로 지정했고, left, right Element는 존재하지 않을 가능성도 있기 때문에 optional prop으로 지정했어요.

### Element 배치 설계
처음에는 좌우 padding을 주고 `display: flex`, `justify-content: space-between`으로 배치하려고 했으나, left, right Element가 optional prop이므로, 존재하지 않게 되면 위치가 다 깨져버리는 문제가 있었어요. 그래서 optional prop이 존재하지 않는 경우도 올바른 위치를 보장하기 위해 각각 Header 내에서 절대적인 위치를 잡아주었어요. 중앙 Element는 `margin: 0 auto`로 중앙정렬, 좌측, 우측 Element는 `position: absolute`로 각각 Header 내부 좌측 우측에 고정시켜주었어요. 그 결과 optional prop이 존재하지 않는 경우도 올바른 위치를 보장하게 됩니다!!

#### 좌측 Element X
<img width="355" alt="스크린샷 2025-01-28 오후 11 08 29" src="https://github.com/user-attachments/assets/e772932d-1263-4e6b-87d6-d5df5929838a" />

#### 우측 Element X
<img width="356" alt="스크린샷 2025-01-28 오후 11 07 27" src="https://github.com/user-attachments/assets/df5ea6f9-a9a3-44cb-b6b1-51d85ba9889d" />

#### 좌, 우측 Element X
<img width="355" alt="스크린샷 2025-01-28 오후 11 10 30" src="https://github.com/user-attachments/assets/d0f60794-bbda-45d3-9318-8b9bd46539fe" />

### 웹 접근성 향상을 위한 aria-label

웹 접근성 향상을 위해 다음과 같이 "페이지 헤더"라는 aria-label을 추가했어요.

<img width="359" alt="스크린샷 2025-01-28 오후 10 23 51" src="https://github.com/user-attachments/assets/4e62829d-b03c-4948-a38b-da901e684f82" />



### Header 상단 고정

Header를 상단고정하기 위해 처음에는 `position: fixed`를 사용했어요. 그러다보니 문서 흐름을 벗어나버려서 page body 부분이 Header 밑으로 깔리게 되는 문제가 있었어요.

이를 해결하기 위해 페이지 공통 레이아웃의 Outlet 부분이 Header의 높이만큼 상단 margin을 갖게 하여 body 부분이 가려지지 않도록 해주었어요. 해결은 되었지만 좋은 방법이라는 생각이 들지 않았어요. 만약 Header의 height이 변경되면 그때마다 Outlet 영역의 상단 margin도 항상 sync를 맞춰주어야 하기 때문에 유지보수 측면에서 좋지 못하다고 생각했기 때문이에요. 더 나은 방법을 고민하던 중에 서현이가 알려준 대로 `position: sticky`를 사용하니 별도로 상단 margin을 주지 않고도 해결되었어요.

`position: sticky`는 초기에 relative처럼 동작해요. 그러다가 부모 스크롤 영역 안에서 지정해준 position에 도달하면 fixed처럼 고정되는데, 이때 `position: fixed`처럼 문서 흐름에서 벗어나서 독립적인 레이어에서 동작하는게 아니라, 문서 흐름을 유지하면서 지정한 위치에 고정돼요. 그래서 고정이 되면서도 page body를 가리지 않게 되는 원리입니다!!

### 🙋🏻‍♂️ 논의가 필요한 점
1. HeaderWrapper가 flex 속성까지 담당하는 방법과 HeaderWrapper 자식 컴포넌트로 Flex 컴포넌트를 위치시켜 Flex 컴포넌트에게 `flex`에 관련된 속성을 위임하는 방법 중 고민했는데, depth 증가 + `align="center"`를 위해 Flex 컴포넌트가 HeaderWrapper의 높이를 상속받아야 하는 것이 불필요하다고 생각해서  HeaderWrapper에서 flex 속성까지 담당하는 방법을 선택했어요. 연서 PR에서도 논의되었던 부분과 같은 결의 내용 같은데, 다음 회의때 결정될 것 같은 부분이라 임시로 이 방법을 택했다고 봐주시면 감사하겠습니다🙏🏻

2. prop 네이밍은 다양한 프로젝트의 header 인터페이스를 참고해서 가장 general하게 사용되는 이름으로 네이밍해보았는데, 너무 길다는 생각이 든다면 언제든 더 나은 네이밍을 추천해주셔도 좋습니다!!

<br />

## 📷 스크린샷

<!-- 팀원들이 이해할 수 있게 구현한 화면을 보여주세요 -->
<img width="358" alt="스크린샷 2025-01-28 오후 11 05 54" src="https://github.com/user-attachments/assets/a8bb63e2-ba1c-4c73-927e-044762a48875" />
