### PR TITLE
Feat : 공통 Spacer 컴포넌트 구현

### DIFF
--- a/src/Menu/page.tsx
+++ b/src/Menu/page.tsx
@@ -1,4 +1,5 @@
 import Header from "@/common/components/Header";
+import Spacer from "@/common/components/Spacer";
 import UserListItemCard from "@/common/components/UserListItemCard";
 import UserProfileAvatar from "@/common/components/UserProfileAvatar";
 import { css } from "@emotion/react";
@@ -18,11 +19,7 @@ import { Link } from "react-router";
 export default function MenuPage() {
   return (
     <>
-      <Header
-        leftElement={"왼쪽"}
-        centerElement={"중앙"}
-        rightElement={"오른쪽"}
-      />
+      <Header left={"왼쪽"} center={"중앙"} right={"오른쪽"} />
       {version}
       <Card variant="surface">menu</Card>
 
@@ -67,9 +64,26 @@ export default function MenuPage() {
         </Flex>
       </UserListContainer>
 
-      {/* fallback이 보여지는 케이스 -> 이미지 로딩 실패시 */}
-      <UserProfileAvatar size="9" />
-      <UserProfileAvatar src="https://picsum.photos/id/237/200/300" size="9" />
+      <div>
+        {/* fallback이 보여지는 케이스 -> 이미지 로딩 실패시 */}
+        <UserProfileAvatar size="9" />
+        {/* 세로 방향 spacing */}
+        <Spacer height="10rem" />
+        <UserProfileAvatar
+          src="https://picsum.photos/id/237/200/300"
+          size="9"
+        />
+      </div>
+      <div css={{ display: "flex" }}>
+        {/* fallback이 보여지는 케이스 -> 이미지 로딩 실패시 */}
+        <UserProfileAvatar size="9" />
+        {/* 가로 방향 spacing */}
+        <Spacer width={"10rem"} />
+        <UserProfileAvatar
+          src="https://picsum.photos/id/237/200/300"
+          size="9"
+        />
+      </div>
     </>
   );
 }

--- a/src/Menu/page.tsx
+++ b/src/Menu/page.tsx
@@ -68,7 +68,7 @@ export default function MenuPage() {
         {/* fallback이 보여지는 케이스 -> 이미지 로딩 실패시 */}
         <UserProfileAvatar size="9" />
         {/* 세로 방향 spacing */}
-        <Spacer height="10rem" />
+        <Spacer height={10} />
         <UserProfileAvatar
           src="https://picsum.photos/id/237/200/300"
           size="9"
@@ -78,7 +78,7 @@ export default function MenuPage() {
         {/* fallback이 보여지는 케이스 -> 이미지 로딩 실패시 */}
         <UserProfileAvatar size="9" />
         {/* 가로 방향 spacing */}
-        <Spacer width={"10rem"} />
+        <Spacer width={10} />
         <UserProfileAvatar
           src="https://picsum.photos/id/237/200/300"
           size="9"

--- a/src/common/components/Spacer.tsx
+++ b/src/common/components/Spacer.tsx
@@ -1,0 +1,9 @@
+type SpacerProps =
+  | { width: `${number}rem`; height?: never }
+  | { width?: never; height: `${number}rem` };
+
+const Spacer = ({ width, height }: SpacerProps) => {
+  return <div css={{ width, height }} />;
+};
+
+export default Spacer;

--- a/src/common/components/Spacer.tsx
+++ b/src/common/components/Spacer.tsx
@@ -1,9 +1,16 @@
 type SpacerProps =
-  | { width: `${number}rem`; height?: never }
-  | { width?: never; height: `${number}rem` };
+  | { width: number; height?: never }
+  | { width?: never; height: number };
 
 const Spacer = ({ width, height }: SpacerProps) => {
-  return <div css={{ width, height }} />;
+  return (
+    <div
+      css={{
+        ...(width && { width: `${width}rem` }),
+        ...(height && { height: `${height}rem` }),
+      }}
+    />
+  );
 };
 
 export default Spacer;

--- a/src/common/components/Spacer.tsx
+++ b/src/common/components/Spacer.tsx
@@ -2,6 +2,16 @@ type SpacerProps =
   | { width: number; height?: never }
   | { width?: never; height: number };
 
+/**
+ * 지정된 너비 또는 높이를 가진 고정된 공간을 추가하는 Spacer 컴포넌트입니다
+ * `width`와 `height` 중 하나만 전달할 수 있습니다.
+ * 전달된 `width` 또는 `height` 값은 rem 단위로 변환됩니다.
+ *
+ * @param {number} [props.width] - Spacer의 너비 (rem 단위).
+ * @param {number} [props.height] - Spacer의 높이 (rem 단위).
+ *
+ * @returns {JSX.Element} Spacer 요소를 반환합니다.
+ */
 const Spacer = ({ width, height }: SpacerProps) => {
   return (
     <div


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #25 

## ☑️ 완료 태스크
- [x] Spacer 공통 컴포넌트 구현
- [x] height(vertical), width(horizontal) 방향으로 space를 줄 수 있도록 인터페이스 뚫기

<br />

## 🔎 PR 내용

<!-- 팀원들에게 PR의 내용을 설명해주세요 -->
<!-- 기록하고 싶은 트러블 슈팅이나 어려웠던 혹은 공유하고 싶었던 챌린징 요소들도 함께 적어줘도 괜찮아요 -->
### 1️⃣ Spacer 컴포넌트란?
- 레이아웃에서 공간을 확보하거나 다른 컴포넌트 간의 간격을 조정하는 컴포넌트
- 🙋🏻‍♀️ 언제 사용하면 좋을까?
  - (1) `CSS 레이아웃(Flex, Grid)에 종속되지 않는 간격 처리` : Spacer 컴포넌트를 사용하면 간격 처리를 위해 별도의 flex나 grid 레이아웃으로 감싸주지 않아도 되어 장점이 있어요.
  - (2) `특정 간격만 독립적으로 제어` : 조건부 렌더링 혹은 특정 상황에서 간격을 추가하거나 제거할수 있어 보다 유연한 UI 설계가 가능해요.
  - (3) `간격을 선언적으로 관리할수 있어요`

### 2️⃣ Props Interface
```ts
type SpacerProps =
  | { width: `${number}rem`; height?: never }
  | { width?: never; height: `${number}rem` };
```
* `width -> 가로 간격 / height -> 세로 간격`
* `width, height 둘 중 하나만 사용 가능 `: 사이 간격을 위한 컴포넌트이기 때문에, width와 height를 동시에 지정하여 사용해야 할 케이스는 없다고 생각하여 둘 중 하나만 사용 가능하도록 타입을 지정했어요. (prop으로 지정하지 않은 것은 auto로 부모 컨테이너 따라가도록)
* `rem 단위 string만 받도록` : 
   - string만 받도록 한 이유 : number type도 받고 내부에서 단위 처리를 해주려고 했으나, (1) radix 시스템에서 보통 스타일링 단위를 prop으로 받을 때 string type으로만 받고 있어 이와 통일해주는 것이 좋다고 생각했고, (2) prop 사용 케이스에 대해 고민하지 않도록 최대한 좁혀주는 것이 좋다고 생각해 단위를 포함한 string type으로만 받도록 인터페이스를 설계 했어요
   -  프로젝트에서 rem 단위로 통일해서 사용하기로 싱크 했으므로, prop을 받을 때부터 이를 검증하기 위해 템플릿 리터럴 string으로 'rem' 단위를 포함하고 있는지 검사하도록 설계했어요.


<br />

## 📷 스크린샷

<!-- 팀원들이 이해할 수 있게 구현한 화면을 보여주세요 -->

// view
<img width="647" alt="image" src="https://github.com/user-attachments/assets/684f1cc6-5e69-44dc-962b-53ab7ef3c843" />
// code
<img width="492" alt="image" src="https://github.com/user-attachments/assets/ebb2cf47-4f19-4f93-8ca3-482fe0c5de20" />


* 순서대로 세로 간격(height = 10rem) / 가로 간격(width = 10rem)

