### PR TITLE
Feat: API Client 개선  - ApiResponse<T> 자동 래핑

### DIFF
--- a/src/common/api/index.ts
+++ b/src/common/api/index.ts
@@ -4,10 +4,8 @@ import type { ApiResponse } from "@/common/types/api";
 import ky, { type Options } from "ky";
 import { redirect } from "react-router";
 
-const API_VERSION = "v1";
-
 const baseApiClient = ky.create({
-  prefixUrl: `${import.meta.env.VITE_API_BASE_URL}/api/${API_VERSION}`,
+  prefixUrl: `${import.meta.env.VITE_API_BASE_URL}`,
   hooks: {
     beforeRequest: [
       (request) => {

--- a/src/common/api/index.ts
+++ b/src/common/api/index.ts
@@ -1,11 +1,12 @@
 import { reissue } from "@/common/api/reissue";
 import { accessTokenStore } from "@/common/stores/accessTokenStore";
-import ky from "ky";
+import type { ApiResponse } from "@/common/types/api";
+import ky, { type Options } from "ky";
 import { redirect } from "react-router";
 
 const API_VERSION = "v1";
 
-export const apiClient = ky.create({
+const baseApiClient = ky.create({
   prefixUrl: `${import.meta.env.VITE_API_BASE_URL}/api/${API_VERSION}`,
   hooks: {
     beforeRequest: [
@@ -26,7 +27,7 @@ export const apiClient = ky.create({
             } = await reissue();
             accessTokenStore.set(accessToken);
 
-            return apiClient(request);
+            return baseApiClient(request);
           } catch (e) {
             accessTokenStore.clear();
             return redirect("/login");
@@ -37,3 +38,15 @@ export const apiClient = ky.create({
     ],
   },
 });
+
+export const apiClient = {
+  get: <T>(url: string, options?: Options) => baseApiClient.get(url, options).json<ApiResponse<T>>(),
+
+  post: <T>(url: string, options?: Options) => baseApiClient.post(url, options).json<ApiResponse<T>>(),
+
+  put: <T>(url: string, options?: Options) => baseApiClient.put(url, options).json<ApiResponse<T>>(),
+
+  delete: <T>(url: string, options?: Options) => baseApiClient.delete(url, options).json<ApiResponse<T>>(),
+
+  patch: <T>(url: string, options?: Options) => baseApiClient.patch(url, options).json<ApiResponse<T>>(),
+};

--- a/src/common/api/index.ts
+++ b/src/common/api/index.ts
@@ -3,8 +3,10 @@ import { accessTokenStore } from "@/common/stores/accessTokenStore";
 import ky from "ky";
 import { redirect } from "react-router";
 
+const API_VERSION = "v1";
+
 export const apiClient = ky.create({
-  prefixUrl: import.meta.env.VITE_API_BASE_URL,
+  prefixUrl: `${import.meta.env.VITE_API_BASE_URL}/api/${API_VERSION}`,
   hooks: {
     beforeRequest: [
       (request) => {

--- a/src/common/api/reissue.ts
+++ b/src/common/api/reissue.ts
@@ -1,4 +1,3 @@
-import type { ApiResponse } from "@/common/types/api";
 import { apiClient } from ".";
 
 interface ReissueBody {
@@ -6,9 +5,7 @@ interface ReissueBody {
 }
 
 export async function reissue() {
-  return apiClient
-    .post<ApiResponse<ReissueBody>>("/auth/reissue/token", {
-      credentials: "include",
-    })
-    .json();
+  return apiClient.post<ReissueBody>("/auth/reissue/token", {
+    credentials: "include",
+  });
 }

--- a/src/common/api/reissue.ts
+++ b/src/common/api/reissue.ts
@@ -1,13 +1,13 @@
 import type { ApiResponse } from "@/common/types/api";
-import ky from "ky";
+import { apiClient } from ".";
 
 interface ReissueBody {
   accessToken: string;
 }
 
 export async function reissue() {
-  return ky
-    .post<ApiResponse<ReissueBody>>(`${import.meta.env.VITE_API_BASE_URL}/auth/reissue/token`, {
+  return apiClient
+    .post<ApiResponse<ReissueBody>>("/auth/reissue/token", {
       credentials: "include",
     })
     .json();

--- a/src/common/api/reissue.ts
+++ b/src/common/api/reissue.ts
@@ -1,11 +1,15 @@
-import { apiClient } from ".";
+import ky from "ky";
+import type { ApiResponse } from "../types/api";
 
 interface ReissueBody {
   accessToken: string;
 }
 
+// apiClient 미사용 - afterResponse hook에서 무한 루프 발생 방지
 export async function reissue() {
-  return apiClient.post<ReissueBody>("/auth/reissue/token", {
-    credentials: "include",
-  });
+  return ky
+    .post<ApiResponse<ReissueBody>>(`${import.meta.env.VITE_API_BASE_URL}/api/v1/auth/reissue/token`, {
+      credentials: "include",
+    })
+    .json();
 }


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
- close #36
 
## ☑️ 완료 태스크
- [x] API 버전 관리 스펙 추가 대응
- [x] `ApiResponse<T>` 자동 래핑 추가

<br />

## 🔎 PR 내용

<!-- 팀원들에게 PR의 내용을 설명해주세요 -->
<!-- 기록하고 싶은 트러블 슈팅이나 어려웠던 혹은 공유하고 싶었던 챌린징 요소들도 함께 적어줘도 괜찮아요 -->


### API 버전 관리 스펙 추가 대응

서버가 API 버전 관리를 도입해서 V1 기준 baseURL 뒤에 `api/v1` prefix가 고정적으로 붙게 되었어요.
버전이 고정되어있는 이상 저 부분도 prefixURL에 포함되면 편할 것 같다고 생각해서 포함시켜주었어요. 단 apiClient 자체가 버전 종속적이지 않게 `API_VERSION`이라는 별도 상수로 관리하도록 하여 책임분리 시켜주었습니다.

물론 나중에 일부 API는 V1, 일부 API는 V2를 찔러야 한다면 별도의 apiClient를 만들어주어야겠지만, 일단은 V1밖에 없는 현재 이 방법이 가장 사용하기 편하고 관리가 쉽다고 판단해서 이렇게 구현했습니다!! 더 좋은 방법이 있으면 제안주셔도 좋습니다~~!!

### `ApiResponse<T>` 자동 래핑

서버 응답이 ApiResponse<T> 타입으로 항상 고정되어있다는 가정 하에, 매번 ApiResponse<T>를 명시해주어야 하는 부분이 번거롭다고 생각했어요.  또 응답 데이터를 매번 JSON으로 파싱하는 것도 반복 작업이라고 생각했어요.

```ts
return apiClient.post<ApiResponse<ReissueBody>>("/auth/reissue/token", {
      credentials: "include",
    })
    .json();
```

그래서 `apiClient.method<T>` 방식으로 사용하면 API Client 내부에서 자동으로 APiResponse 타입 래핑 및 json()까지 처리해주는 방식으로 변경해보았어요. 쿠키 포함 여부는 API에 따라 다를 것 같아 API Client에서 따로 처리하지는 않았습니다.

```ts
return apiClient.post<ReissueBody>("/auth/reissue/token", {
    credentials: "include",
  });
```
