### PR TITLE
Feat: pr 리뷰 요청 글 전체 조회 api 단 구현

### DIFF
--- a/src/ReviewRequest/list/apis/query-pr-reviews.ts
+++ b/src/ReviewRequest/list/apis/query-pr-reviews.ts
@@ -1,0 +1,49 @@
+import { apiClient } from "@/common/api";
+import type { ApiResponse } from "@/common/types/api";
+
+export interface QueryPrReviewsQueryParams {
+  /** PR 현재 상태 : 보내지 않을시 모든 상태 조회 */
+  status?: "open" | "closed";
+  /** 정렬 순서 */
+  order?: "createdAt-desc" | "createdAt-asc" | "hitCount-desc" | "hitCount-asc";
+  /** 직군별 필터링 */
+  position?: "BACKEND" | "FRONTEND";
+  /** 마지막으로 조회된 요청글 id  */
+  lastReviewId?: number;
+  /** 페이지 사이즈 (기본 20)  */
+  size?: number;
+}
+
+/**
+ * PR 리뷰 요청글 리스트 아이템
+ * @
+ */
+export interface PrReviewListItem {
+  /** 작성자 프로필 사진 URL */
+  profileImageUrl: string;
+  /** 작성자 유저 태그 */
+  username: string;
+  /** 요청글 상태 */
+  status: string;
+  /** 분야 태그 */
+  position: string;
+  /** PR 리뷰 요청글 제목 */
+  title: string;
+  /** 조회수 */
+  hitCount: number;
+  /** 작성일자/시각 */
+  createdAt: string;
+}
+
+export interface QueryPrReviewsResponse {
+  /** PR 리뷰 요청글 리스트 */
+  prReviews: PrReviewListItem[];
+  /** 마지막 페이지 여부 */
+  isLast: boolean;
+}
+
+export async function queryPrReviews(params?: QueryPrReviewsQueryParams): Promise<ApiResponse<QueryPrReviewsResponse>> {
+  return apiClient.get<QueryPrReviewsResponse>("api/v1/pr-reviews", {
+    searchParams: params as Record<string, string | number>,
+  });
+}

--- a/src/ReviewRequest/list/hooks/apis/querykeys.ts
+++ b/src/ReviewRequest/list/hooks/apis/querykeys.ts
@@ -1,0 +1,6 @@
+import type { QueryPrReviewsQueryParams } from "../../apis/query-pr-reviews";
+
+export const prListQueryKeys = {
+  all: () => ["pr-list"],
+  prReviews: (params?: QueryPrReviewsQueryParams) => [...prListQueryKeys.all(), "pr-reviews", params],
+};

--- a/src/ReviewRequest/list/hooks/apis/useQueryPrReviews.ts
+++ b/src/ReviewRequest/list/hooks/apis/useQueryPrReviews.ts
@@ -1,0 +1,15 @@
+import type { ApiResponse } from "@/common/types/api";
+import { useQuery } from "@tanstack/react-query";
+import {
+  type QueryPrReviewsQueryParams,
+  type QueryPrReviewsResponse,
+  queryPrReviews,
+} from "../../apis/query-pr-reviews";
+import { prListQueryKeys } from "./querykeys";
+
+export const useQueryPrReviews = (params?: QueryPrReviewsQueryParams) => {
+  return useQuery<ApiResponse<QueryPrReviewsResponse>, Error>({
+    queryFn: () => queryPrReviews(params),
+    queryKey: prListQueryKeys.prReviews(params),
+  });
+};


### PR DESCRIPTION
<!-- PR의 제목은 이슈 제목과 동일 -->
close #22 

## ☑️ 완료 태스크
- [x] api 개발
- [x] api hook 개발

<br />

## 🔎 PR 내용

<!-- 팀원들에게 PR의 내용을 설명해주세요 -->
<!-- 기록하고 싶은 트러블 슈팅이나 어려웠던 혹은 공유하고 싶었던 챌린징 요소들도 함께 적어줘도 괜찮아요 -->

공통 사용 부분인 PR 리뷰 요청 글 전체 조회 (`QueryPrReviews`) api 단 구현한 PR 먼저 main에 반영합니다

* [> PR 리뷰 요청 글 전체 조회 API 명세](https://www.notion.so/PR-190aada9f1c9812f87dfe69b649a163a?source=copy_link)


* api hook 사용부 example
```tsx
 const { data, isLoading, error } = useQueryPrReviews(Object.keys(parsedFilters))
 
// 리스트 데이터만 사용한다면 다음과 같이 파싱
 const prReviews = data?.data.prReviews
```

<br />

## 📷 스크린샷

<!-- 팀원들이 이해할 수 있게 구현한 화면을 보여주세요 -->


- 개발중인 브랜치에서 목록 불러오기 / 필터링 잘 동작함을 확인했습니다!

https://github.com/user-attachments/assets/9a61dff8-0b88-4053-92df-177d91436349


